### PR TITLE
Upgrade to TensorFlow 1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,68 @@
 Overview
 ============
-A project that trains a LSTM recurrent neural network over a dataset of MIDI files. More information can be found on the [writeup about this project](http://yoavz.com/music_rnn/) or the [final report](http://yoavz.com/music_rnn_paper.pdf) written. *Warning: Some parts of this codebase are unfinished.*
+A project that trains a LSTM recurrent neural network over a dataset of MIDI files. Implemented in TensorFlow. More information can be found on the [writeup about this project](http://yoavz.com/music_rnn/) or the [final report](http://yoavz.com/music_rnn_paper.pdf) written. *Warning: Some parts of this codebase are unfinished.*
 
 Dependencies
 ============
 
-* Python 2.7
+* Python 2.7 (due to python-midi)
 * Anaconda
 * Numpy (http://www.numpy.org/)
 * Tensorflow (https://github.com/tensorflow/tensorflow) - 0.8
 * Python Midi (https://github.com/vishnubob/python-midi.git)
+  * some newer fork than available via PyPI
 * Mingus (https://github.com/bspaans/python-mingus)
 * Matplotlib (http://matplotlib.org/)
 
 Basic Usage
 ===========
 
-1. Run `./install.sh` to create conda env, install dependencies and download data
-2. `source activate music_rnn` to activate the conda environment
-3. Run `python nottingham_util.py` to generate the sequences and chord mapping file to `data/nottingham.pickle`
-4. Run `python rnn.py --run_name YOUR_RUN_NAME_HERE` to start training the model. Use the grid object in `rnn.py` to edit hyperparameter
-   configurations.
-5. `source deactivate` to deactivate the conda environment
+## Install the environment:
+
+First install Anaconda.
+
+Then create conda environment `music_rnn`, install dependencies and download data:
+
+```shell
+./install.sh
+```
+
+## Activate the conda environment
+
+```shell
+source activate music_rnn
+```
+
+## Prepare data
+
+Generate the sequences and chord mapping file to `data/nottingham.pickle`:
+
+```shell
+python nottingham_util.py
+```
+
+## Train a model
+
+Start training a model:
+
+```shell
+python rnn.py --run_name <run_name>
+```
+
+Use the grid object in `rnn.py` to edit hyperparameter configurations.
+
+## Generate a song using a trained model
+
+```shell
+python rnn_sample.py --config_file <some_config_file>
+```
+
+Output will be stored in `best.midi`.
+
+## Deactivate conda environment
+
+When you're finished and want to switch to another project you can deactivate the conda environment:
+
+```shell
+source deactivate
+```

--- a/model.py
+++ b/model.py
@@ -49,7 +49,7 @@ class Model(object):
             else:
                 raise Exception("Invalid cell type: {}".format(cell_type))
 
-            cell = cell_class(hidden_size)
+            cell = cell_class(hidden_size, state_is_tuple=False)
             if training:
                 return rnn.DropoutWrapper(cell, output_keep_prob = dropout_prob)
             else:
@@ -61,7 +61,8 @@ class Model(object):
             self.seq_input_dropout = self.seq_input
 
         self.cell = rnn.MultiRNNCell(
-            [create_cell(input_dim)] + [create_cell(hidden_size) for i in range(1, num_layers)])
+            [create_cell(input_dim)] + [create_cell(hidden_size) for i in range(1, num_layers)],
+            state_is_tuple=False)
 
         batch_size = tf.shape(self.seq_input_dropout)[0]
         self.initial_state = self.cell.zero_state(batch_size, tf.float32)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ git+https://github.com/vishnubob/python-midi#egg=midi
 #https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow-0.8.0-cp27-none-linux_x86_64.whl
 # OS X, Python 2.7, CPU:
 # https://storage.googleapis.com/tensorflow/mac/tensorflow-0.8.0-py2-none-any.whl
-tensorflow==1.2.1
+tensorflow-gpu==1.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ mingus
 numpy
 git+https://github.com/vishnubob/python-midi#egg=midi
 # Linux, Python 2.7, GPU
-https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow-0.8.0-cp27-none-linux_x86_64.whl
+#https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow-0.8.0-cp27-none-linux_x86_64.whl
 # OS X, Python 2.7, CPU:
 # https://storage.googleapis.com/tensorflow/mac/tensorflow-0.8.0-py2-none-any.whl
+tensorflow==1.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ numpy
 git+https://github.com/vishnubob/python-midi#egg=midi
 # Linux, Python 2.7, GPU
 https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow-0.8.0-cp27-none-linux_x86_64.whl
+# OS X, Python 2.7, CPU:
+# https://storage.googleapis.com/tensorflow/mac/tensorflow-0.8.0-py2-none-any.whl

--- a/rnn.py
+++ b/rnn.py
@@ -128,8 +128,8 @@ if __name__ == '__main__':
             with tf.variable_scope("model", reuse=True):
                 valid_model = model_class(config, training=False)
 
-            saver = tf.train.Saver(tf.all_variables(), max_to_keep=40)
-            tf.initialize_all_variables().run()
+            saver = tf.train.Saver(tf.global_variables(), max_to_keep=40)
+            tf.global_variables_initializer().run()
 
             # training
             early_stop_best_loss = None

--- a/rnn_sample.py
+++ b/rnn_sample.py
@@ -52,7 +52,7 @@ if __name__ == '__main__':
         with tf.variable_scope("model", reuse=None):
             sampling_model = model_class(config)
 
-        saver = tf.train.Saver(tf.all_variables())
+        saver = tf.train.Saver(tf.global_variables())
         model_path = os.path.join(os.path.dirname(args.config_file), 
             config.model_name)
         saver.restore(session, model_path)

--- a/rnn_separate.py
+++ b/rnn_separate.py
@@ -122,8 +122,8 @@ if __name__ == '__main__':
             with tf.variable_scope("model", reuse=True):
                 valid_model = model_class(config, training=False)
 
-            saver = tf.train.Saver(tf.all_variables())
-            tf.initialize_all_variables().run()
+            saver = tf.train.Saver(tf.global_variables())
+            tf.global_variables_initializer().run()
 
             # training
             early_stop_best_loss = None

--- a/rnn_separate.py
+++ b/rnn_separate.py
@@ -7,9 +7,9 @@ import logging
 import random
 import string
 import pprint
- 
+
 import numpy as np
-import tensorflow as tf    
+import tensorflow as tf
 import matplotlib.pyplot as plt
 
 import midi_util
@@ -20,7 +20,7 @@ from rnn import get_config_name, DefaultConfig
 from model import Model, NottinghamSeparate
 
 if __name__ == '__main__':
-    np.random.seed()      
+    np.random.seed()
 
     parser = argparse.ArgumentParser(description='Music RNN')
     parser.add_argument('--choice', type=str, default='melody',
@@ -57,7 +57,7 @@ if __name__ == '__main__':
         raise Exception("Run name {} already exists, choose a different one", format(run_folder))
     os.makedirs(run_folder)
 
-    logger = logging.getLogger(__name__) 
+    logger = logging.getLogger(__name__)
     logger.setLevel(logging.INFO)
     logger.addHandler(logging.StreamHandler())
     logger.addHandler(logging.FileHandler(os.path.join(run_folder, "training.log")))
@@ -113,7 +113,7 @@ if __name__ == '__main__':
 
         logger.info(config)
         config_file_path = os.path.join(run_folder, get_config_name(config) + '.config')
-        with open(config_file_path, 'w') as f: 
+        with open(config_file_path, 'w') as f:
             cPickle.dump(config, f)
 
         with tf.Graph().as_default(), tf.Session() as session:
@@ -153,7 +153,7 @@ if __name__ == '__main__':
                         saver.save(session, os.path.join(run_folder, config.model_name))
                         saved_flag = True
                 elif not start_saving:
-                    start_saving = True 
+                    start_saving = True
                     logger.info('Valid loss increased for the first time, will start saving models')
                     saver.save(session, os.path.join(run_folder, config.model_name))
                     saved_flag = True

--- a/rnn_test.py
+++ b/rnn_test.py
@@ -62,7 +62,7 @@ if __name__ == '__main__':
         with tf.variable_scope("model", reuse=None):
             test_model = model_class(config, training=False)
 
-        saver = tf.train.Saver(tf.all_variables())
+        saver = tf.train.Saver(tf.global_variables())
         model_path = os.path.join(os.path.dirname(args.config_file), 
             config.model_name)
         saver.restore(session, model_path)


### PR DESCRIPTION
I wanted to use this model as a baseline for new models - be able to run it and compare against it. Since the project was using old TensorFlow 0.8.0 and that doesn't run on current CUDA toolkit 8 (only up to 7.5) I decided to upgrade to the latest TensorFlow 1.2.1.

Some parts were easily converted automatically using the `tf_upgrade.py` script. Some changes in RNN API happened between 0.8 and 0.12 so I fixed them manually.

There's one warning left on a deprecated feature:

```
WARNING:tensorflow:<tensorflow.python.ops.rnn_cell_impl.BasicLSTMCell object at 0x7f80c23b0050>: Using a concatenated state is slower and will soon be deprecated.  Use state_is_tuple=True.
```

We should change the RNN `state` representation to some compatible form. So far I only set `state_is_tuple=False` which matches the old RNN code.

I was able to get it running on CUDA 8 and Tesla K80. One epoch takes around 75 seconds. Is that good?

I tried also to upgrade to Python 3, but python-midi still does not support it. So leaving that for later.